### PR TITLE
feat: add markdown relative link verifier and fixtures

### DIFF
--- a/verify/08-check-markdown-links.sh
+++ b/verify/08-check-markdown-links.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Usage: ./verify/08-check-markdown-links.sh <markdown-file>
+# Verifies that all relative/local links inside a markdown file point to existing files/directories.
+set -euo pipefail
+
+FILE="${1:?usage: $0 <markdown-file>}"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+[ -f "$FILE" ] || fail "file not found: $FILE"
+DIR=$(dirname "$FILE")
+
+has_errors=0
+
+# Find all links of the form [text](url) or ![alt](url)
+# We use grep to output only the matches, one per line.
+while read -r line; do
+  [ -n "$line" ] || continue
+
+  # Extract the url part between ( and )
+  url=$(printf '%s' "$line" | sed -E 's/^\!?\[[^]]*\]\((.*)\)$/\1/')
+
+  # Skip external URLs, mailto, tel, and local anchor hashes
+  if [[ "$url" =~ ^(https?|mailto|tel): ]] || [[ "$url" == \#* ]]; then
+    continue
+  fi
+
+  # Strip query parameters and hash anchors
+  url="${url%%\?*}"
+  url="${url%%#*}"
+
+  [ -n "$url" ] || continue
+
+  # URL Decode (convert %XX to character)
+  decoded_url=$(printf '%b' "${url//%/\\x}")
+
+  resolved_path="$DIR/$decoded_url"
+
+  if [ ! -e "$resolved_path" ]; then
+    echo "FAIL: Broken link \"$line\" -> path does not exist: \"$resolved_path\"" >&2
+    has_errors=1
+  fi
+done < <(grep -oE '\!?\[[^]]*\]\([^)]+\)' "$FILE" || true)
+
+if [ "$has_errors" -ne 0 ]; then
+  exit 1
+fi
+
+echo "PASS: All local markdown links exist."
+exit 0

--- a/verify/fixtures/08-check-markdown-links/fail/fail.md
+++ b/verify/fixtures/08-check-markdown-links/fail/fail.md
@@ -1,0 +1,4 @@
+# Fail Fixture
+
+This file contains a broken relative link that does not exist on the filesystem:
+[Broken Link](./does-not-exist.txt)

--- a/verify/fixtures/08-check-markdown-links/pass/exists.txt
+++ b/verify/fixtures/08-check-markdown-links/pass/exists.txt
@@ -1,0 +1,1 @@
+This file exists and is used as a target for passing markdown links.

--- a/verify/fixtures/08-check-markdown-links/pass/pass.md
+++ b/verify/fixtures/08-check-markdown-links/pass/pass.md
@@ -1,0 +1,15 @@
+# Pass Fixture
+
+This is a valid relative link to a file in the same directory:
+[Exists](./exists.txt)
+
+This is a valid relative link to a file in the parent repository structure:
+[Readme](../../../../README.md)
+
+This is an image tag pointing to a valid file:
+![Image](./exists.txt)
+
+These are external links, anchors, and emails which should be skipped and not cause a failure:
+* [Google](https://google.com)
+* [Self Anchor](#pass-fixture)
+* [Email Us](mailto:info@gofrantic.com)


### PR DESCRIPTION
Closes #6. Adds a markdown relative link verifier to check that all relative/local links or images referenced inside markdown files resolve to existing files or directories. Also includes passing and failing fixtures.