### PR TITLE
verify: two reusable verifiers — red-green patch + report artifacts (Bounty 06)

### DIFF
--- a/verify/check-red-green-patch.sh
+++ b/verify/check-red-green-patch.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Usage: ./verify/check-red-green-patch.sh <fixture-dir>
+# Verifies a "bug fix proven by a failing test" deliverable (the red-green pair).
+# <fixture-dir> must contain: src/ (unpatched tree), test.sh (the proving test,
+# run with the tree as cwd), patch.diff (the fix, unified diff, -p1 from src/).
+# PASS (exit 0) iff: test FAILS on the unpatched tree (red), the patch applies
+# cleanly, and the same test PASSES on the patched tree (green).
+set -euo pipefail
+
+FIX="${1:?usage: $0 <fixture-dir>}"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+[ -d "$FIX" ] || fail "fixture dir not found: $FIX"
+FIX="$(cd "$FIX" && pwd)"
+[ -d "$FIX/src" ] || fail "missing src/ in fixture"
+[ -f "$FIX/test.sh" ] || fail "missing test.sh in fixture"
+[ -f "$FIX/patch.diff" ] || fail "missing patch.diff in fixture"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cp -R "$FIX/src" "$WORK/tree"
+
+# RED: the test must fail against the unpatched tree.
+if (cd "$WORK/tree" && timeout 50 bash "$FIX/test.sh" >/dev/null 2>&1); then
+  fail "test PASSES on the unpatched tree — it does not expose the bug (no red)"
+fi
+echo "red: test fails on unpatched tree ✓"
+
+# APPLY: the patch must apply cleanly.
+patch -p1 -d "$WORK/tree" --no-backup-if-mismatch < "$FIX/patch.diff" >/dev/null 2>&1 \
+  || fail "patch.diff does not apply cleanly to src/"
+echo "apply: patch applies cleanly ✓"
+
+# GREEN: the same test must pass against the patched tree.
+if ! (cd "$WORK/tree" && timeout 50 bash "$FIX/test.sh" >/dev/null 2>&1); then
+  fail "test still FAILS after the patch — the fix does not satisfy its own test (no green)"
+fi
+echo "green: test passes on patched tree ✓"
+
+echo "PASS: red-green pair verified (test exposes the bug, patch fixes it)"

--- a/verify/check-report-artifacts.sh
+++ b/verify/check-report-artifacts.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Usage: ./verify/check-report-artifacts.sh <report.md> [min-bullets]
+# Verifies a written field-report deliverable (e.g. bounty 01's install-friction
+# report): at least <min-bullets> (default 10) DISTINCT bullet points, and every
+# bullet must quote at least one real artifact in `backticks` (an exact command,
+# error string, file path, or URL). Duplicate bullets are rejected.
+set -euo pipefail
+
+REPORT="${1:?usage: $0 <report.md> [min-bullets]}"
+MIN="${2:-10}"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+[ -f "$REPORT" ] || fail "report not found: $REPORT"
+
+# Collect bullet blocks: a block starts at a line whose first non-space char is
+# "-" or "*" followed by a space, and runs until the next bullet or blank line.
+total=0; no_artifact=0
+declare -A seen; dup=0
+while IFS= read -r block; do
+  [ -n "$block" ] || continue
+  total=$((total+1))
+  norm="$(printf '%s' "$block" | tr -s ' ' | tr '[:upper:]' '[:lower:]')"
+  if [ -n "${seen[$norm]:-}" ]; then dup=$((dup+1)); else seen[$norm]=1; fi
+  case "$block" in
+    *'`'*'`'*) : ;;
+    *) no_artifact=$((no_artifact+1)) ;;
+  esac
+done < <(awk '
+  /^[[:space:]]*[-*][[:space:]]/ { if (buf != "") print buf; buf = $0; inb = 1; next }
+  /^[[:space:]]*$/               { if (buf != "") print buf; buf = ""; inb = 0; next }
+  inb                            { buf = buf " " $0; next }
+  END                            { if (buf != "") print buf }
+' "$REPORT")
+
+distinct=$((total - dup))
+echo "bullets: $total total, $distinct distinct, $no_artifact without a backtick-quoted artifact"
+
+[ "$total" -ge 1 ] || fail "no bullet points found"
+[ "$dup" -eq 0 ] || fail "$dup duplicate bullet(s) — every bullet must be distinct"
+[ "$distinct" -ge "$MIN" ] || fail "need >=$MIN distinct bullets, got $distinct"
+[ "$no_artifact" -eq 0 ] || fail "$no_artifact bullet(s) quote no artifact — each bullet must contain an exact command, error, path, or URL in backticks"
+
+echo "PASS: $distinct distinct bullets, every one quoting a real artifact"

--- a/verify/fixtures/check-red-green-patch/fail/patch.diff
+++ b/verify/fixtures/check-red-green-patch/fail/patch.diff
@@ -1,0 +1,7 @@
+--- a/greet.sh	2026-06-11 12:18:41.352055732 +0000
++++ b/greet.sh	2026-06-11 12:18:41.357055732 +0000
+@@ -1,3 +1,3 @@
+ #!/usr/bin/env bash
+-# prints a greeting for the given name; promises "hello, <name>"
++# emits a greeting for the given name; promises "hello, <name>"
+ printf 'helo, %s\n' "${1:-world}"

--- a/verify/fixtures/check-red-green-patch/fail/src/greet.sh
+++ b/verify/fixtures/check-red-green-patch/fail/src/greet.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# prints a greeting for the given name; promises "hello, <name>"
+printf 'helo, %s\n' "${1:-world}"

--- a/verify/fixtures/check-red-green-patch/fail/test.sh
+++ b/verify/fixtures/check-red-green-patch/fail/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# expects cwd = the source tree under test
+out="$(bash greet.sh world)"
+[ "$out" = "hello, world" ]

--- a/verify/fixtures/check-red-green-patch/pass/patch.diff
+++ b/verify/fixtures/check-red-green-patch/pass/patch.diff
@@ -1,0 +1,7 @@
+--- a/greet.sh	2026-06-11 12:18:41.352055732 +0000
++++ b/greet.sh	2026-06-11 12:18:41.352055732 +0000
+@@ -1,3 +1,3 @@
+ #!/usr/bin/env bash
+ # prints a greeting for the given name; promises "hello, <name>"
+-printf 'helo, %s\n' "${1:-world}"
++printf 'hello, %s\n' "${1:-world}"

--- a/verify/fixtures/check-red-green-patch/pass/src/greet.sh
+++ b/verify/fixtures/check-red-green-patch/pass/src/greet.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# prints a greeting for the given name; promises "hello, <name>"
+printf 'helo, %s\n' "${1:-world}"

--- a/verify/fixtures/check-red-green-patch/pass/test.sh
+++ b/verify/fixtures/check-red-green-patch/pass/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# expects cwd = the source tree under test
+out="$(bash greet.sh world)"
+[ "$out" = "hello, world" ]

--- a/verify/fixtures/check-report-artifacts/fail.md
+++ b/verify/fixtures/check-report-artifacts/fail.md
@@ -1,0 +1,12 @@
+# Install friction report — example fail fixture
+
+- The install was pretty rough overall.
+- It took longer than expected.
+- Ran `npm install -g sourcey` and it worked.
+- Docs were confusing in places.
+- I had to google several errors.
+- The theme looked wrong at first.
+- Deploying was the hardest part.
+- The config file had odd defaults.
+- The sitemap was broken initially.
+- Eventually everything worked fine.

--- a/verify/fixtures/check-report-artifacts/pass.md
+++ b/verify/fixtures/check-report-artifacts/pass.md
@@ -1,0 +1,12 @@
+# Install friction report — example pass fixture
+
+- Ran `npm install -g sourcey` and hit `EACCES: permission denied` on the global prefix.
+- Re-ran under `sudo npm install -g sourcey`; install completed in 41s.
+- `npx sourcey init` prompted for a config path but the docs at `https://sourcey.com/docs` never mention the prompt.
+- The generated `sourcey.config.json` defaulted `theme: "auto"`, which rendered black-on-black in dark mode.
+- Build step `sourcey build` failed first run with `Error: ENOENT readme.md` — repo used `README.rst`.
+- Converted with `pandoc README.rst -o README.md` and the build passed.
+- Deploy docs assume Vercel; deploying to my own nginx box needed a manual `try_files $uri $uri/ /index.html;` rule.
+- The sitemap generator wrote absolute `http://localhost:3000` URLs until I set `siteUrl` in the config.
+- Total wall-clock from clean machine to live page: `1h 12m` measured with `time`.
+- The only doc page covering custom domains 404s: `https://sourcey.com/docs/custom-domains`.


### PR DESCRIPTION
Delivers **Bounty 06** (claimed: https://github.com/auscaster/frantic-board/issues/6#issuecomment-4680430716) — two reusable verifiers, each with one passing and one failing fixture.

## 1 · `verify/check-red-green-patch.sh`
Verifies a **bug fix proven by a failing test** (the PR-contains-failing-test check named in the bounty brief). Fixture dir = `src/` (unpatched tree) + `test.sh` + `patch.diff`. PASS iff: test FAILS on the unpatched tree (red) → patch applies cleanly → same test PASSES (green). Copies the tree to a temp dir; never mutates the fixture; 50s timeouts on test runs.

Fixtures: `verify/fixtures/check-red-green-patch/pass/` (typo bug + fixing patch) · `fail/` (patch applies cleanly but is comment-only, so the test stays red).

## 2 · `verify/check-report-artifacts.sh`
Verifies a **written field-report deliverable** (e.g. Bounty 01's install-friction report): ≥N distinct bullets (default 10, second arg overrides), every bullet must quote ≥1 real artifact in backticks (exact command / error / path / URL), duplicate bullets rejected. Handles wrapped multi-line bullets.

Fixtures: `verify/fixtures/check-report-artifacts/pass.md` · `fail.md` (10 bullets, 9 with no quoted artifact).

## Self-check (your harness, run before this PR)
```
$ ./verify/06-check-verifier-fixtures.sh verify/check-red-green-patch.sh \
    verify/fixtures/check-red-green-patch/pass verify/fixtures/check-red-green-patch/fail
PASS: verifier has usage line and distinguishes pass/fail fixtures

$ ./verify/06-check-verifier-fixtures.sh verify/check-report-artifacts.sh \
    verify/fixtures/check-report-artifacts/pass.md verify/fixtures/check-report-artifacts/fail.md
PASS: verifier has usage line and distinguishes pass/fail fixtures
```

Both run in well under 60s, pure bash + coreutils (`patch`, `awk`), no paid dependencies, no network. Neither deliverable type is covered by an existing `verify/` script (the bounty-02 red-green criterion is currently checked by hand; report quality in bounty 01 likewise).

Honest disclosure per RULES: operator account `jakerated-r` was created 2026-04-10 (<3 months) — if that makes this round standing-only, understood; deliverable stands on its own either way. No receipt bonus claimed (work was not run through runx). Contact: TikTok **@jakerated_r**.