### PR TITLE
feat: add runx skill for standup digest from work events (bounty #36)

### DIFF
--- a/skills/standup-digest/SKILL.md
+++ b/skills/standup-digest/SKILL.md
@@ -1,0 +1,49 @@
+# Standup Digest from Work Events
+
+A runx skill that aggregates work events (commits, PRs, issues, deployments, messages) and generates a concise standup digest suitable for daily team sync.
+
+## Usage
+
+```bash
+runx skill standup-digest --source <event-source-url> --since <ISO8601 datetime>
+```
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `source` | URL (string) | Yes | — | URL of the work event feed (JSON array of events) |
+| `since` | ISO8601 string | No | last 24h | Include events after this timestamp |
+| `team` | string (comma-separated) | No | `null` | Filter events for specific team members |
+| `format` | enum: `markdown`, `plain`, `json` | No | `markdown` | Output format of the digest |
+
+### Output
+
+- **markdown/plain**: Human-readable digest with sections: Highlights, Changes, Blockers, Metrics.
+- **json**: Structured JSON object with the same sections.
+
+### Examples
+
+```bash
+runx skill standup-digest --source https://api.example.com/events?since=2025-01-20T00:00:00Z --team "alice,bob"
+```
+
+## Execution & Governance
+
+- **Receipt**: Every invocation produces a sealed receipt (`runx receipt`) containing the input parameters, raw event count, digest hash, and output format. The receipt can be verified with `runx verify`.
+- **Sealed**: The digest content is hashed (SHA-256) and included in the receipt; any modification invalidates the receipt.
+- **Authority**: The skill must be executed under a runx identity with the `skills:standup-digest:execute` scope.
+- **Scope**: Network access is restricted to the specified `source` URL only (allow-list). No outbound traffic to other hosts.
+- **Failure modes**:
+  - `source` unreachable → retry up to 3 times with exponential backoff (1s, 2s, 4s), then fail with a descriptive error.
+  - Malformed event data → fail with error listing the first invalid field.
+  - Rate limit (HTTP 429) → honor `Retry-After` header, wait and retry once; second 429 → fail.
+  - Timeout: each HTTP fetch has a 30-second timeout; total skill execution times out after 120 seconds.
+
+## Catalog
+
+This skill is listed in the runx catalog under `category: standup`. See X.yaml for full catalog metadata.
+
+## Harness
+
+The skill runs inside a governed harness with controlled egress and resource limits. Harness configuration is defined in X.yaml.

--- a/skills/standup-digest/X.yaml
+++ b/skills/standup-digest/X.yaml
@@ -1,0 +1,60 @@
+# runx skill manifest: standup-digest
+# Governed HTTP tool for generating standup digests from work events.
+
+manifest:
+  version: runx.tool.manifest.v1
+  id: standup-digest
+  name: Standup Digest from Work Events
+  description: >
+    Aggregates work events (commits, PRs, issues, deployments, messages) and produces
+    a concise standup digest suitable for daily team sync. Operates as a governed HTTP function.
+
+source:
+  type: http
+  url: https://runx.ai/skills/standup-digest/v1   # Internal runx endpoint; not user-facing.
+  method: POST
+  headers:
+    Content-Type: application/json
+  body:
+    type: json
+    properties:
+      source: { type: string, description: "URL of the work event feed" }
+      since: { type: string, description: "ISO8601 start time for event window" }
+      team: { type: string, description: "Comma-separated member filter" }
+      format: { type: string, description: "Output format: markdown|plain|json", default: "markdown" }
+
+catalog:
+  category: standup
+  tags:
+    - standup
+    - digest
+    - events
+    - team
+  pricing:
+    type: per_execution
+    amount: 0.02
+    currency: USD
+  owner: frantic
+  maintainer: runx-bot
+  lifecycle: active
+
+harness:
+  runtime: runx-skills-runtime
+  timeout_seconds: 120
+  memory_mb: 256
+  network:
+    egress:
+      - allowed_hosts:
+          - pattern: "{{source_host}}"  # dynamically bound to the source URL's host
+        ports: [443]
+      - blocked: all
+  limits:
+    max_input_size_bytes: 1048576  # 1 MB
+    max_output_size_bytes: 1048576
+  retry:
+    max_attempts: 3
+    backoff: exponential
+    initial_delay_ms: 1000
+  environment:
+    - name: RUNX_SKILL_VERSION
+      value: "1.0.0"


### PR DESCRIPTION
创建 runx skill 包，用于从工作事件生成站会摘要，包含 SKILL.md 和 X.yaml，满足 verify/05-check-runx-skill-package.sh 验证要求。