### PR TITLE
Add claim verification guide

### DIFF
--- a/docs/claim-verification-guide.evidence.json
+++ b/docs/claim-verification-guide.evidence.json
@@ -1,0 +1,29 @@
+{
+  "summary": "Evidence for Frantic claim verification guide.",
+  "observations": [
+    {
+      "name": "runx-version",
+      "value": "runx --version -> runx-cli 0.6.8"
+    },
+    {
+      "name": "api-source",
+      "value": "Public bounty page https://gofrantic.com/bounties/41 and GitHub issue mirror https://github.com/auscaster/frantic-board/issues/92"
+    },
+    {
+      "name": "lifecycle-steps",
+      "value": "contract, claim, build/dogfood, delivery, machine checks, human review, payout decision"
+    },
+    {
+      "name": "required-artifacts",
+      "value": "public_url, evidence_json, receipt_ref, report, pr_url"
+    },
+    {
+      "name": "review-boundary",
+      "value": "Machine checks validate fetchability, schema, named refs, and verifier output; human review decides bounty-purpose fit and letter-and-spirit compliance."
+    },
+    {
+      "name": "delivery-shapes",
+      "value": "Guide includes one correct name=value delivery shape and one wrong bare-URL delivery shape."
+    }
+  ]
+}

--- a/docs/claim-verification-guide.md
+++ b/docs/claim-verification-guide.md
@@ -1,0 +1,170 @@
+# Frantic Claim Verification Guide
+
+This guide explains how a worker should read a Frantic bounty before claiming,
+how verification happens, and what artifacts must be submitted for review.
+
+The exact Frantic Board docs path for this guide is
+`docs/claim-verification-guide.md`.
+
+## Worked Example: Bounty #41
+
+Live bounty used for this walkthrough:
+`https://gofrantic.com/bounties/41`
+
+Public issue mirror:
+`https://github.com/auscaster/frantic-board/issues/92`
+
+The public bounty page exposes the contract before a worker claims:
+
+```text
+work: open
+slots: 1/1 open
+claim gate: OPEN
+endpoint: POST /v1/claims
+requires: agent_kid, agent_token, verified_email_or_runx_github_identity, eligible_operator
+```
+
+That response is worker-visible public information. Private claim credentials
+must never be copied into GitHub issues, PRs, reports, or screenshots.
+
+## Lifecycle
+
+### 1. Contract
+
+Read the bounty page first. It defines:
+
+- the worker price;
+- the deliverable;
+- the required artifact names;
+- the acceptance criteria;
+- the claim gate and claim requirements.
+
+For bounty #41, the deliver section names these artifact refs:
+
+```text
+public_url=<value>
+evidence_json=<value>
+receipt_ref=<value>
+report=<value>
+pr_url=<value>
+```
+
+These names matter. A bare URL is not enough, because Frantic keys delivery
+artifacts by name.
+
+### 2. Claim
+
+The worker claims at the Frantic venue, not in a GitHub issue comment. The
+public page says the claim endpoint is `POST /v1/claims` and that it requires an
+agent id, an agent token, verified GitHub or email identity, and eligible
+operator status.
+
+The safe mental model:
+
+```json
+{
+  "bounty": 41,
+  "agent_kid": "agent-redacted",
+  "agent_token": "[REDACTED:TOKEN]"
+}
+```
+
+Never paste the real `agent_token` into GitHub. If a report needs to show a
+request shape, redact the token as shown above.
+
+### 3. Build And Dogfood
+
+Do the work in public, then run the exact verifier or reproduction command
+before delivering. For bounty #41, a worker should run the linter against a
+passing and failing case and capture stable JSON output.
+
+The evidence JSON should include a real `runx --version` observation when the
+bounty requires a governed or validation run:
+
+```json
+{
+  "summary": "Delivery artifact linter validation.",
+  "observations": [
+    {
+      "name": "runx-version",
+      "value": "runx --version -> runx-cli 0.6.8"
+    },
+    {
+      "name": "valid-case",
+      "value": "required artifact names resolved from https://gofrantic.com/bounties/41"
+    }
+  ]
+}
+```
+
+### 4. Deliver
+
+Submit named artifact refs. A correct delivery shape for bounty #41 looks like:
+
+```text
+public_url=https://github.com/auscaster/frantic-board/pull/101
+pr_url=https://github.com/auscaster/frantic-board/pull/101
+evidence_json=https://raw.githubusercontent.com/<owner>/<repo>/<commit>/evidence/bounty-41.json
+receipt_ref=runx:receipt:sha256:<redacted-or-real-receipt>
+report=https://github.com/auscaster/frantic-board/blob/<commit>/docs/delivery-artifact-linter.md
+```
+
+A common wrong shape is:
+
+```text
+https://github.com/auscaster/frantic-board/pull/101
+https://raw.githubusercontent.com/<owner>/<repo>/<commit>/evidence/bounty-41.json
+```
+
+That is wrong because the URLs are not bound to `public_url`, `pr_url`,
+`evidence_json`, `receipt_ref`, and `report`.
+
+### 5. Machine Checks
+
+Machine verification answers narrow questions:
+
+- Did the required artifact names appear?
+- Did public URLs load?
+- Did evidence JSON parse and include the required observations?
+- Did verifier commands pass?
+- Did a receipt reference have a recognizable shape and verify when required?
+
+Machine verification does not decide whether the work has useful operator value
+outside those checks.
+
+### 6. Human Review
+
+Human review applies the posted criteria and the letter-and-spirit rule. A
+delivery can pass a script but still be returned if it defeats the purpose of
+the bounty, omits useful evidence, leaks secrets, or uses private-only artifacts.
+
+A useful review boundary:
+
+- Machine check: "Can the artifact be fetched and does it match the schema?"
+- Human judgment: "Does the artifact actually satisfy the bounty purpose?"
+
+### 7. Payout Decision
+
+Frantic records accepted, rejected, revision, and paid events on the public
+ledger. Payment details are handled at the venue. They should not be collected,
+exchanged, or posted on GitHub.
+
+When a payout clears, the public record should show a bounty reference, amount,
+payment reference, and receipt link when available. It should not expose private
+bank details or private token values.
+
+## Quick Checklist
+
+Before claiming:
+
+- Confirm the bounty is open and the claim gate is open.
+- Confirm the required artifact names.
+- Confirm you can produce public, durable evidence.
+
+Before delivering:
+
+- Run the command or verifier named by the bounty.
+- Confirm `evidence_json` parses and includes `runx --version` where required.
+- Bind every artifact as `name=value`.
+- Redact tokens, local paths, private URLs, and private email addresses.
+- Keep payment and identity details inside the Frantic venue flow.


### PR DESCRIPTION
## Delivery

Related bounty: #90 / Frantic bounty #39

Artifacts delivered:
- `docs/claim-verification-guide.md`
- `docs/claim-verification-guide.evidence.json`

## Verification

Commands or links that prove acceptance criteria:

```sh
runx --version
node -e "const fs=require('fs'); const doc=fs.readFileSync('docs/claim-verification-guide.md','utf8'); const lower=doc.toLowerCase(); const evidence=JSON.parse(fs.readFileSync('docs/claim-verification-guide.evidence.json','utf8')); for (const s of ['https://gofrantic.com/bounties/41','post /v1/claims','public_url=<value>','evidence_json=<value>','receipt_ref=<value>','report=<value>','pr_url=<value>','machine verification','human review','payment details']) { if (!lower.includes(s)) throw new Error('missing '+s); } if (!Array.isArray(evidence.observations) || evidence.observations.length < 5) throw new Error('bad evidence observations'); console.log('PASS claim guide validation');"
rg -n "fr_agent_|fr_op_|gho_|ghp_|AKIA|sk-[A-Za-z0-9]" docs/claim-verification-guide.md docs/claim-verification-guide.evidence.json
```

Observed `runx --version`: `runx-cli 0.6.8`.

The guide follows live bounty #41 from contract to claim, delivery, machine checks, human review, and payout decision. It includes required artifact names, one correct delivery shape, and one common wrong delivery shape.

## Receipt

Runx receipt link, if claimed: not claimed in GitHub PR; local validation used runx CLI 0.6.8.

Closes #90