### PR TITLE
[codex] Add delivery artifact linter

### DIFF
--- a/scripts/delivery-artifact-linter.mjs
+++ b/scripts/delivery-artifact-linter.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+// Usage: node scripts/delivery-artifact-linter.mjs --bounty <url|file> [--artifact name=value ...] [--artifacts-file file] [--no-network]
+
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const usage = `Usage:
+  node scripts/delivery-artifact-linter.mjs --bounty <url|file> --artifact name=value [--artifact name=value ...]
+  node scripts/delivery-artifact-linter.mjs --bounty <url|file> --artifacts-file <json> [--no-network]
+
+The linter prints stable JSON and exits 0 on pass, 1 on failed checks, 2 on usage/runtime errors.`;
+
+const RECEIPT_REF_RE =
+  /^(runx:receipt:sha256:[a-f0-9]{64}|runx:receipt:[A-Za-z0-9:_-]+|frantic:receipt:[A-Za-z0-9:_-]+|https:\/\/(?:gofrantic\.com|api\.gofrantic\.com|runx\.ai)\/\S*(?:receipt|receipts)\S*)$/;
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage);
+    return 0;
+  }
+  if (!options.bounty) {
+    throw usageError("missing --bounty");
+  }
+
+  const artifactMap = new Map();
+  for (const artifact of options.artifacts) {
+    const parsed = parseArtifactRef(artifact);
+    artifactMap.set(parsed.name, parsed.value);
+  }
+  if (options.artifactsFile) {
+    for (const [name, value] of Object.entries(await loadArtifactFile(options.artifactsFile))) {
+      artifactMap.set(name, String(value));
+    }
+  }
+
+  const bountyEnvelope = await loadJsonReference(options.bounty, { checkNetwork: !options.noNetwork });
+  const bounty = bountyEnvelope.bounty ?? bountyEnvelope;
+  const requiredArtifacts = requiredArtifactNames(bounty);
+  const expectedPackage = bounty.criteria?.verification?.expected_package_name ?? null;
+
+  const checks = [];
+  const errors = [];
+  const warnings = [];
+
+  for (const name of requiredArtifacts) {
+    if (!artifactMap.has(name)) {
+      errors.push(error("missing_artifact", `${name} is required by the bounty but was not provided`, { name }));
+    }
+  }
+
+  const providedArtifacts = Object.fromEntries([...artifactMap.entries()].sort(([a], [b]) => a.localeCompare(b)));
+
+  for (const [name, value] of artifactMap) {
+    if (isUrlArtifactName(name)) {
+      const result = await checkReferenceLive(name, value, { checkNetwork: !options.noNetwork });
+      checks.push(result);
+      if (!result.ok) errors.push(resultToError(result));
+    }
+  }
+
+  if (artifactMap.has("evidence_json")) {
+    const evidenceCheck = await checkEvidenceJson(artifactMap.get("evidence_json"), {
+      checkNetwork: !options.noNetwork,
+    });
+    checks.push(evidenceCheck);
+    for (const detail of evidenceCheck.details.filter((item) => !item.ok)) {
+      errors.push(error(detail.id, detail.message, { artifact: "evidence_json" }));
+    }
+  }
+
+  if (artifactMap.has("receipt_ref")) {
+    const value = artifactMap.get("receipt_ref");
+    const ok = RECEIPT_REF_RE.test(value);
+    checks.push({ id: "receipt_ref_shape", ok, artifact: "receipt_ref", value });
+    if (!ok) {
+      errors.push(
+        error("malformed_receipt_ref", "receipt_ref must be a runx/frantic receipt ref or public receipt URL", {
+          value,
+        }),
+      );
+    }
+  }
+
+  if (artifactMap.has("report")) {
+    const reportCheck = await checkReportDepth(artifactMap.get("report"), { checkNetwork: !options.noNetwork });
+    checks.push(reportCheck);
+    if (!reportCheck.ok) {
+      errors.push(
+        error("report_too_shallow", "report should include at least six Markdown bullet points", {
+          bullet_count: reportCheck.bullet_count,
+        }),
+      );
+    }
+  }
+
+  if (expectedPackage) {
+    const packageCheck = checkPackageBinding(expectedPackage, artifactMap);
+    checks.push(packageCheck);
+    if (!packageCheck.ok) {
+      errors.push(
+        error("package_name_mismatch", `artifact refs do not bind expected package ${expectedPackage}`, {
+          expected_package: expectedPackage,
+          inspected_artifacts: packageCheck.inspected_artifacts,
+        }),
+      );
+    }
+  }
+
+  for (const [name] of artifactMap) {
+    if (!/^[a-z][a-z0-9_]*$/.test(name)) {
+      warnings.push({ id: "artifact_name_unusual", message: `artifact name ${name} is not snake_case` });
+    }
+  }
+
+  const result = {
+    schema: "frantic.delivery_artifact_lint.v1",
+    ok: errors.length === 0,
+    bounty: {
+      number: bounty.number ?? null,
+      title: bounty.title ?? null,
+      source: options.bounty,
+      expected_package: expectedPackage,
+    },
+    required_artifacts: requiredArtifacts,
+    provided_artifacts: providedArtifacts,
+    errors,
+    warnings,
+    checks,
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+  return result.ok ? 0 : 1;
+}
+
+function parseArgs(args) {
+  const options = {
+    artifacts: [],
+    artifactsFile: null,
+    bounty: null,
+    help: false,
+    noNetwork: false,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--bounty") {
+      options.bounty = takeValue(args, ++index, arg);
+    } else if (arg === "--artifact") {
+      options.artifacts.push(takeValue(args, ++index, arg));
+    } else if (arg === "--artifacts-file") {
+      options.artifactsFile = takeValue(args, ++index, arg);
+    } else if (arg === "--no-network") {
+      options.noNetwork = true;
+    } else {
+      throw usageError(`unknown argument ${arg}`);
+    }
+  }
+  return options;
+}
+
+function takeValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) throw usageError(`${flag} requires a value`);
+  return value;
+}
+
+function parseArtifactRef(raw) {
+  const separator = raw.indexOf("=");
+  if (separator < 1) throw usageError(`artifact ref must be name=value, got ${raw}`);
+  return {
+    name: raw.slice(0, separator).trim(),
+    value: raw.slice(separator + 1).trim(),
+  };
+}
+
+async function loadArtifactFile(file) {
+  const parsed = JSON.parse(await readTextReference(file, { checkNetwork: false }));
+  if (Array.isArray(parsed)) {
+    return Object.fromEntries(parsed.map((item) => [item.name, item.value]));
+  }
+  if (parsed && typeof parsed === "object") return parsed;
+  throw new Error("artifacts file must be a JSON object or array of {name,value}");
+}
+
+function requiredArtifactNames(bounty) {
+  const names = bounty.requiredArtifacts ?? bounty.required_artifacts ?? bounty.criteria?.artifacts ?? [];
+  return [...new Set(names)].sort();
+}
+
+function isUrlArtifactName(name) {
+  return name.endsWith("_url") || name === "public_url" || name === "report" || name === "evidence_json";
+}
+
+async function checkReferenceLive(name, value, options) {
+  if (isReceiptOnly(name)) {
+    return { id: "reference_live", ok: true, artifact: name, skipped: "receipt ref is checked separately" };
+  }
+  try {
+    const resolved = resolveReference(value);
+    if (resolved.kind === "file") {
+      return { id: "reference_live", ok: existsSync(resolved.path), artifact: name, mode: "file", value };
+    }
+    if (!["http:", "https:"].includes(resolved.url.protocol)) {
+      return { id: "reference_live", ok: false, artifact: name, mode: "url", value, reason: "unsupported protocol" };
+    }
+    if (!options.checkNetwork) {
+      return { id: "reference_live", ok: true, artifact: name, mode: "network", value, skipped: "network disabled" };
+    }
+    const response = await fetchWithTimeout(resolved.url.href, { method: "GET" });
+    return {
+      id: "reference_live",
+      ok: response.ok,
+      artifact: name,
+      mode: "network",
+      status: response.status,
+      value,
+    };
+  } catch (err) {
+    return { id: "reference_live", ok: false, artifact: name, value, reason: err.message };
+  }
+}
+
+function isReceiptOnly(name) {
+  return name === "receipt_ref";
+}
+
+async function checkEvidenceJson(reference, options) {
+  const details = [];
+  try {
+    const evidence = JSON.parse(await readTextReference(reference, options));
+    details.push({
+      id: "evidence_summary",
+      ok: typeof evidence.summary === "string" && evidence.summary.length >= 80,
+      message: "evidence_json.summary must be at least 80 characters",
+    });
+    details.push({
+      id: "evidence_observations",
+      ok: Array.isArray(evidence.observations) && evidence.observations.length >= 6,
+      message: "evidence_json.observations must contain at least six items",
+    });
+  } catch (err) {
+    details.push({ id: "bad_evidence_json", ok: false, message: `evidence_json could not be parsed: ${err.message}` });
+  }
+  return { id: "evidence_json_shape", ok: details.every((item) => item.ok), artifact: "evidence_json", details };
+}
+
+async function checkReportDepth(reference, options) {
+  const text = await readTextReference(reference, options);
+  const bulletCount = text.split(/\r?\n/).filter((line) => /^\s*[-*]\s+\S/.test(line)).length;
+  return { id: "report_depth", ok: bulletCount >= 6, artifact: "report", bullet_count: bulletCount };
+}
+
+function checkPackageBinding(expectedPackage, artifactMap) {
+  const inspectedNames = ["public_url", "source_url", "x_yaml", "skill_md", "pr_url"].filter((name) => artifactMap.has(name));
+  const inspectedValues = inspectedNames.map((name) => artifactMap.get(name));
+  return {
+    id: "package_binding",
+    ok: inspectedValues.some((value) => value.includes(expectedPackage)),
+    expected_package: expectedPackage,
+    inspected_artifacts: inspectedNames,
+  };
+}
+
+async function loadJsonReference(reference, options) {
+  return JSON.parse(await readTextReference(reference, options));
+}
+
+async function readTextReference(reference, options) {
+  const resolved = resolveReference(reference);
+  if (resolved.kind === "file") {
+    return readFile(resolved.path, "utf8");
+  }
+  if (!options.checkNetwork) {
+    throw new Error(`network disabled for ${reference}`);
+  }
+  const response = await fetchWithTimeout(resolved.url.href, { method: "GET" });
+  if (!response.ok) throw new Error(`${reference} returned HTTP ${response.status}`);
+  return response.text();
+}
+
+function resolveReference(reference) {
+  if (/^https?:\/\//.test(reference)) {
+    return { kind: "url", url: new URL(reference) };
+  }
+  if (reference.startsWith("file://")) {
+    return { kind: "file", path: fileURLToPath(reference) };
+  }
+  return { kind: "file", path: path.resolve(process.cwd(), reference) };
+}
+
+async function fetchWithTimeout(url, init = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal, redirect: "follow" });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function resultToError(result) {
+  return error("dead_or_unreadable_url", `${result.artifact} did not resolve as a live public reference`, result);
+}
+
+function error(id, message, detail = {}) {
+  return { ...detail, id, message };
+}
+
+function usageError(message) {
+  const err = new Error(`${message}\n\n${usage}`);
+  err.usage = true;
+  return err;
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err) => {
+    console.error(err.usage ? err.message : `delivery-artifact-linter: ${err.message}`);
+    process.exitCode = err.usage ? 2 : 2;
+  });

--- a/verify/08-check-delivery-artifact-linter.sh
+++ b/verify/08-check-delivery-artifact-linter.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Usage: ./verify/08-check-delivery-artifact-linter.sh
+# Verifies the delivery artifact linter pass/fail fixtures.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/delivery-artifact-linter.mjs"
+FIXTURES="$ROOT/verify/fixtures/delivery-artifact-linter"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+command -v node >/dev/null 2>&1 || fail "node is required"
+[ -f "$SCRIPT" ] || fail "missing linter script"
+
+node "$SCRIPT" \
+  --bounty "$FIXTURES/bounty-41.json" \
+  --artifacts-file "$FIXTURES/pass-artifacts.json" \
+  --no-network \
+  > /tmp/frantic-delivery-artifact-linter-pass.json
+
+if node "$SCRIPT" \
+  --bounty "$FIXTURES/bounty-37-runx-skill.json" \
+  --artifacts-file "$FIXTURES/fail-artifacts.json" \
+  --no-network \
+  > /tmp/frantic-delivery-artifact-linter-fail.json; then
+  fail "failing fixture unexpectedly passed"
+fi
+
+node -e "const fs=require('fs'); const pass=JSON.parse(fs.readFileSync('/tmp/frantic-delivery-artifact-linter-pass.json','utf8')); if (!pass.ok) process.exit(1); const fail=JSON.parse(fs.readFileSync('/tmp/frantic-delivery-artifact-linter-fail.json','utf8')); if (fail.ok || fail.errors.length < 4) process.exit(1);"
+
+echo "PASS: delivery artifact linter distinguishes pass/fail fixtures"

--- a/verify/fixtures/delivery-artifact-linter/README.md
+++ b/verify/fixtures/delivery-artifact-linter/README.md
@@ -1,0 +1,42 @@
+# Delivery Artifact Linter Fixtures
+
+These fixtures exercise `scripts/delivery-artifact-linter.mjs`, a preflight helper
+for Frantic deliveries.
+
+Run the passing case from a fresh checkout:
+
+```bash
+node scripts/delivery-artifact-linter.mjs \
+  --bounty verify/fixtures/delivery-artifact-linter/bounty-41.json \
+  --artifacts-file verify/fixtures/delivery-artifact-linter/pass-artifacts.json \
+  --no-network
+```
+
+Run the failing case:
+
+```bash
+node scripts/delivery-artifact-linter.mjs \
+  --bounty verify/fixtures/delivery-artifact-linter/bounty-37-runx-skill.json \
+  --artifacts-file verify/fixtures/delivery-artifact-linter/fail-artifacts.json \
+  --no-network
+```
+
+The failing fixture catches at least four mistakes:
+
+- missing required artifact keys for a runx skill bounty
+- an unreadable local `pr_url` reference
+- malformed `evidence_json`
+- malformed `receipt_ref`
+- a `public_url` package-name mismatch against `least-privilege-plan`
+
+Use it on a live bounty and proposed delivery:
+
+```bash
+node scripts/delivery-artifact-linter.mjs \
+  --bounty https://gofrantic.com/v1/bounties/41 \
+  --artifact public_url=https://github.com/auscaster/frantic-board/pull/123 \
+  --artifact pr_url=https://github.com/auscaster/frantic-board/pull/123 \
+  --artifact evidence_json=https://raw.githubusercontent.com/OWNER/REPO/COMMIT/verify/fixtures/delivery-artifact-linter/valid-evidence.json \
+  --artifact receipt_ref=runx:receipt:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  --artifact report=https://raw.githubusercontent.com/OWNER/REPO/COMMIT/verify/fixtures/delivery-artifact-linter/report.md
+```

--- a/verify/fixtures/delivery-artifact-linter/bounty-37-runx-skill.json
+++ b/verify/fixtures/delivery-artifact-linter/bounty-37-runx-skill.json
@@ -1,0 +1,38 @@
+{
+  "ok": true,
+  "bounty": {
+    "number": 37,
+    "title": "runx skill: least-privilege grant plan",
+    "requiredArtifacts": [
+      "public_url",
+      "source_url",
+      "pr_url",
+      "x_yaml",
+      "skill_md",
+      "evidence_json",
+      "verification_json",
+      "receipt_ref",
+      "report"
+    ],
+    "criteria": {
+      "artifacts": [
+        "public_url",
+        "source_url",
+        "pr_url",
+        "x_yaml",
+        "skill_md",
+        "evidence_json",
+        "verification_json",
+        "receipt_ref",
+        "report"
+      ],
+      "verification": {
+        "profile": "published_artifact_v1",
+        "artifact_kind": "runx_skill",
+        "expected_package_name": "least-privilege-plan",
+        "runx_cli_min_version": "0.6.6",
+        "requires_public_receipt": true
+      }
+    }
+  }
+}

--- a/verify/fixtures/delivery-artifact-linter/bounty-41.json
+++ b/verify/fixtures/delivery-artifact-linter/bounty-41.json
@@ -1,0 +1,29 @@
+{
+  "ok": true,
+  "bounty": {
+    "number": 41,
+    "title": "Publish a Frantic delivery artifact linter",
+    "requiredArtifacts": [
+      "public_url",
+      "evidence_json",
+      "receipt_ref",
+      "report",
+      "pr_url"
+    ],
+    "criteria": {
+      "artifacts": [
+        "public_url",
+        "evidence_json",
+        "receipt_ref",
+        "report",
+        "pr_url"
+      ],
+      "verification": {
+        "profile": "published_artifact_v1",
+        "artifact_kind": "generic",
+        "runx_cli_min_version": "0.6.6",
+        "requires_public_receipt": true
+      }
+    }
+  }
+}

--- a/verify/fixtures/delivery-artifact-linter/fail-artifacts.json
+++ b/verify/fixtures/delivery-artifact-linter/fail-artifacts.json
@@ -1,0 +1,7 @@
+{
+  "public_url": "https://runx.ai/x/pqmashiro-commits/not-the-package@0.1.0",
+  "pr_url": "verify/fixtures/delivery-artifact-linter/missing-pr.html",
+  "evidence_json": "verify/fixtures/delivery-artifact-linter/invalid-evidence.json",
+  "receipt_ref": "receipt:totally-not-a-receipt",
+  "report": "verify/fixtures/delivery-artifact-linter/short-report.md"
+}

--- a/verify/fixtures/delivery-artifact-linter/invalid-evidence.json
+++ b/verify/fixtures/delivery-artifact-linter/invalid-evidence.json
@@ -1,0 +1,4 @@
+{
+  "summary": "",
+  "observations": []
+}

--- a/verify/fixtures/delivery-artifact-linter/pass-artifacts.json
+++ b/verify/fixtures/delivery-artifact-linter/pass-artifacts.json
@@ -1,6 +1,6 @@
 {
-  "public_url": "https://github.com/auscaster/frantic-board/pull/0",
-  "pr_url": "https://github.com/auscaster/frantic-board/pull/0",
+  "public_url": "https://github.com/auscaster/frantic-board/pull/114",
+  "pr_url": "https://github.com/auscaster/frantic-board/pull/114",
   "evidence_json": "verify/fixtures/delivery-artifact-linter/valid-evidence.json",
   "receipt_ref": "frantic:receipt:badge:agent-370f81:round-one",
   "report": "verify/fixtures/delivery-artifact-linter/report.md"

--- a/verify/fixtures/delivery-artifact-linter/pass-artifacts.json
+++ b/verify/fixtures/delivery-artifact-linter/pass-artifacts.json
@@ -1,0 +1,7 @@
+{
+  "public_url": "https://github.com/auscaster/frantic-board/pull/0",
+  "pr_url": "https://github.com/auscaster/frantic-board/pull/0",
+  "evidence_json": "verify/fixtures/delivery-artifact-linter/valid-evidence.json",
+  "receipt_ref": "frantic:receipt:badge:agent-370f81:round-one",
+  "report": "verify/fixtures/delivery-artifact-linter/report.md"
+}

--- a/verify/fixtures/delivery-artifact-linter/report.md
+++ b/verify/fixtures/delivery-artifact-linter/report.md
@@ -1,0 +1,11 @@
+# Delivery Artifact Linter Report
+
+- Adds `scripts/delivery-artifact-linter.mjs`, a no-dependency Node script for pre-submission artifact checks.
+- Reads a live Frantic bounty URL or captured public API response and extracts exact required artifact names.
+- Accepts proposed artifact refs as repeated `--artifact name=value` flags or a JSON `--artifacts-file`.
+- Emits stable JSON with `ok`, `errors`, `warnings`, `checks`, required artifact names, and provided artifact refs.
+- Validates `evidence_json` shape by requiring a long summary and at least six observations.
+- Validates `receipt_ref` shape against public runx or Frantic receipt references.
+- Checks report depth with a six-bullet minimum so prose-only reports fail early.
+- Checks package-name binding when a runx skill bounty declares `expected_package_name`.
+- Includes pass and fail fixtures so workers and reviewers can rerun the behavior from a fresh checkout.

--- a/verify/fixtures/delivery-artifact-linter/report.md
+++ b/verify/fixtures/delivery-artifact-linter/report.md
@@ -1,6 +1,8 @@
 # Delivery Artifact Linter Report
 
 - Adds `scripts/delivery-artifact-linter.mjs`, a no-dependency Node script for pre-submission artifact checks.
+- Public PR: https://github.com/auscaster/frantic-board/pull/114.
+- Validation used runx CLI version `runx-cli 0.6.8`.
 - Reads a live Frantic bounty URL or captured public API response and extracts exact required artifact names.
 - Accepts proposed artifact refs as repeated `--artifact name=value` flags or a JSON `--artifacts-file`.
 - Emits stable JSON with `ok`, `errors`, `warnings`, `checks`, required artifact names, and provided artifact refs.

--- a/verify/fixtures/delivery-artifact-linter/short-report.md
+++ b/verify/fixtures/delivery-artifact-linter/short-report.md
@@ -1,0 +1,3 @@
+# Too Short
+
+This report intentionally has no useful bullet depth.

--- a/verify/fixtures/delivery-artifact-linter/valid-evidence.json
+++ b/verify/fixtures/delivery-artifact-linter/valid-evidence.json
@@ -1,10 +1,18 @@
 {
-  "summary": "Delivery artifact linter fixture evidence showing that the tool can read bounty-required artifact names, validate submitted refs, and emit stable JSON before a worker submits a Frantic delivery.",
+  "summary": "Delivery artifact linter evidence for Frantic bounty #41, binding PR #114, runx CLI 0.6.8, the script path, fixture paths, and the exact pass/fail commands used before submitting the delivery.",
   "observations": [
     {
       "name": "runx_cli_version",
       "value": "runx-cli 0.6.8",
       "source": "local command: runx --version"
+    },
+    {
+      "name": "pr_url",
+      "value": "https://github.com/auscaster/frantic-board/pull/114"
+    },
+    {
+      "name": "public_url",
+      "value": "https://github.com/auscaster/frantic-board/pull/114"
     },
     {
       "name": "script_path",
@@ -20,7 +28,7 @@
     },
     {
       "name": "valid_case",
-      "value": "pass-artifacts.json provides all required keys and readable local evidence/report fixtures"
+      "value": "pass-artifacts.json provides public_url, pr_url, evidence_json, receipt_ref, and report for bounty #41"
     },
     {
       "name": "invalid_case",
@@ -29,6 +37,14 @@
     {
       "name": "command",
       "value": "node scripts/delivery-artifact-linter.mjs --bounty verify/fixtures/delivery-artifact-linter/bounty-41.json --artifacts-file verify/fixtures/delivery-artifact-linter/pass-artifacts.json --no-network"
+    },
+    {
+      "name": "failing_command",
+      "value": "node scripts/delivery-artifact-linter.mjs --bounty verify/fixtures/delivery-artifact-linter/bounty-37-runx-skill.json --artifacts-file verify/fixtures/delivery-artifact-linter/fail-artifacts.json --no-network"
+    },
+    {
+      "name": "failing_case_result",
+      "value": "The failing fixture reports missing_artifact, dead_or_unreadable_url, evidence_summary, malformed_receipt_ref, report_too_shallow, and package_name_mismatch."
     }
   ]
 }

--- a/verify/fixtures/delivery-artifact-linter/valid-evidence.json
+++ b/verify/fixtures/delivery-artifact-linter/valid-evidence.json
@@ -1,0 +1,34 @@
+{
+  "summary": "Delivery artifact linter fixture evidence showing that the tool can read bounty-required artifact names, validate submitted refs, and emit stable JSON before a worker submits a Frantic delivery.",
+  "observations": [
+    {
+      "name": "runx_cli_version",
+      "value": "runx-cli 0.6.8",
+      "source": "local command: runx --version"
+    },
+    {
+      "name": "script_path",
+      "value": "scripts/delivery-artifact-linter.mjs"
+    },
+    {
+      "name": "input_schema",
+      "value": "--bounty <url|file> plus --artifact name=value or --artifacts-file <json>"
+    },
+    {
+      "name": "live_bounty_source",
+      "value": "Captured public API response for Frantic bounty #41 in bounty-41.json"
+    },
+    {
+      "name": "valid_case",
+      "value": "pass-artifacts.json provides all required keys and readable local evidence/report fixtures"
+    },
+    {
+      "name": "invalid_case",
+      "value": "fail-artifacts.json demonstrates missing keys, bad evidence_json, bad receipt_ref, dead local PR ref, and package mismatch"
+    },
+    {
+      "name": "command",
+      "value": "node scripts/delivery-artifact-linter.mjs --bounty verify/fixtures/delivery-artifact-linter/bounty-41.json --artifacts-file verify/fixtures/delivery-artifact-linter/pass-artifacts.json --no-network"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `scripts/delivery-artifact-linter.mjs`, a no-dependency Node preflight helper for Frantic delivery artifact refs.
- Add pass/fail fixtures and fixture README under `verify/fixtures/delivery-artifact-linter/`.
- Add `verify/08-check-delivery-artifact-linter.sh` to replay the fixture pair from a fresh checkout.

## Why
Workers and reviewers need the same fast check before a delivery is submitted: required artifact names, evidence JSON shape, public references, receipt refs, and runx skill package-name binding should fail early with stable JSON.

## Validation
- `node scripts/delivery-artifact-linter.mjs --bounty verify/fixtures/delivery-artifact-linter/bounty-41.json --artifacts-file verify/fixtures/delivery-artifact-linter/pass-artifacts.json --no-network`
- `node scripts/delivery-artifact-linter.mjs --bounty verify/fixtures/delivery-artifact-linter/bounty-37-runx-skill.json --artifacts-file verify/fixtures/delivery-artifact-linter/fail-artifacts.json --no-network`
- `runx --version` -> `runx-cli 0.6.8`

The passing fixture returns `ok: true`; the failing fixture reports missing artifacts, an unreadable PR reference, malformed evidence JSON, malformed receipt ref, shallow report, and package-name mismatch.