### PR TITLE
[codex] Add evidence redaction fixtures

### DIFF
--- a/verify/09-check-evidence-redaction-fixtures.mjs
+++ b/verify/09-check-evidence-redaction-fixtures.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Usage: node verify/09-check-evidence-redaction-fixtures.mjs
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "fixtures/evidence-redaction");
+const unsafePatterns = [
+  { id: "synthetic_secret", re: /SYNTHETIC_SECRET_DO_NOT_USE_[A-Za-z0-9_]+/ },
+  { id: "windows_local_path", re: /C:\\Users\\[^\\]+\\/ },
+  { id: "posix_local_path", re: /\/home\/[^/]+\// },
+  { id: "private_url", re: /https:\/\/internal\.example\.invalid\/\S+/ },
+  { id: "private_email", re: /\b[A-Za-z0-9._%+-]+@example\.invalid\b/ },
+];
+
+const safeFiles = [
+  "safe-redacted-secret.json",
+  "safe-redacted-local-path.json",
+  "safe-redacted-private-url.json",
+];
+const unsafeFiles = [
+  "unsafe-synthetic-secret.json",
+  "unsafe-local-path.json",
+  "unsafe-private-url-email.md",
+];
+
+const errors = [];
+const observations = [];
+
+for (const file of safeFiles) {
+  const parsed = JSON.parse(await readFile(path.join(root, file), "utf8"));
+  if (typeof parsed.summary !== "string" || parsed.summary.length < 40) {
+    errors.push(`${file}: missing useful summary`);
+  }
+  if (!Array.isArray(parsed.observations) || parsed.observations.length === 0) {
+    errors.push(`${file}: missing observations`);
+  }
+  observations.push({ file, kind: "safe_json", status: "validated" });
+}
+
+for (const file of unsafeFiles) {
+  const text = await readFile(path.join(root, file), "utf8");
+  const matches = unsafePatterns.filter((pattern) => pattern.re.test(text)).map((pattern) => pattern.id);
+  if (matches.length === 0) {
+    errors.push(`${file}: expected at least one unsafe synthetic category`);
+  }
+  observations.push({ file, kind: "unsafe_synthetic", categories: matches });
+}
+
+const files = await readdir(root);
+if (files.filter((file) => safeFiles.includes(file) || unsafeFiles.includes(file)).length < 6) {
+  errors.push("fixture pack must contain at least six named fixtures");
+}
+
+const result = {
+  schema: "frantic.evidence_redaction_fixture_validation.v1",
+  ok: errors.length === 0,
+  fixture_root: "verify/fixtures/evidence-redaction",
+  observations,
+  errors,
+};
+
+console.log(JSON.stringify(result, null, 2));
+process.exitCode = result.ok ? 0 : 1;

--- a/verify/fixtures/evidence-redaction/README.md
+++ b/verify/fixtures/evidence-redaction/README.md
@@ -1,0 +1,22 @@
+# Evidence Redaction Fixtures
+
+Reusable fixtures for checking whether Frantic evidence is useful without
+leaking secrets, private addresses, local paths, or private URLs.
+
+Safe fixtures are valid JSON and include both `summary` and `observations`.
+Unsafe fixtures intentionally contain synthetic sentinels only; they are not
+live credentials, customer data, or private inboxes.
+
+Expected reviewer action:
+
+- Safe fixtures should pass shape checks and may be used as positive examples.
+- Unsafe fixtures should be rejected or redacted before public delivery.
+- `SYNTHETIC_SECRET_DO_NOT_USE_...` marks fake secrets.
+- `user@example.invalid` and `internal.example.invalid` mark non-routable private identifiers.
+- `C:\Users\agent\...` and `/home/agent/...` mark local paths that should not appear in public evidence.
+
+Run the fixture validator:
+
+```bash
+node verify/09-check-evidence-redaction-fixtures.mjs
+```

--- a/verify/fixtures/evidence-redaction/evidence.json
+++ b/verify/fixtures/evidence-redaction/evidence.json
@@ -11,6 +11,14 @@
       "value": "verify/fixtures/evidence-redaction/"
     },
     {
+      "name": "pr_url",
+      "value": "https://github.com/auscaster/frantic-board/pull/115"
+    },
+    {
+      "name": "public_url",
+      "value": "https://github.com/auscaster/frantic-board/pull/115"
+    },
+    {
       "name": "safe_fixtures",
       "value": [
         "safe-redacted-secret.json",

--- a/verify/fixtures/evidence-redaction/evidence.json
+++ b/verify/fixtures/evidence-redaction/evidence.json
@@ -1,0 +1,53 @@
+{
+  "summary": "Evidence redaction fixture pack for Frantic bounty #38, containing three safe JSON examples, three unsafe synthetic examples, validation results, redaction categories, and proposed verifier usage.",
+  "observations": [
+    {
+      "name": "runx_cli_version",
+      "value": "runx-cli 0.6.8",
+      "source": "local command: runx --version"
+    },
+    {
+      "name": "fixture_root",
+      "value": "verify/fixtures/evidence-redaction/"
+    },
+    {
+      "name": "safe_fixtures",
+      "value": [
+        "safe-redacted-secret.json",
+        "safe-redacted-local-path.json",
+        "safe-redacted-private-url.json"
+      ],
+      "validation_result": "all parse as JSON and include summary plus observations"
+    },
+    {
+      "name": "unsafe_fixtures",
+      "value": [
+        "unsafe-synthetic-secret.json",
+        "unsafe-local-path.json",
+        "unsafe-private-url-email.md"
+      ],
+      "validation_result": "all contain only synthetic sentinel secrets, local paths, private URLs, or private emails"
+    },
+    {
+      "name": "redaction_categories",
+      "value": [
+        "secret",
+        "local_path",
+        "private_url",
+        "private_email"
+      ]
+    },
+    {
+      "name": "validation_command",
+      "value": "node verify/09-check-evidence-redaction-fixtures.mjs"
+    },
+    {
+      "name": "proposed_verifier_usage",
+      "value": "Use safe fixtures as positive examples and unsafe fixtures as blocking negative cases for future evidence_json public-safety checks."
+    },
+    {
+      "name": "reviewer_action",
+      "value": "Reject unsafe evidence unless raw values are replaced with [REDACTED_SECRET], [LOCAL_PATH], [PRIVATE_URL], or [PRIVATE_EMAIL]."
+    }
+  ]
+}

--- a/verify/fixtures/evidence-redaction/report.md
+++ b/verify/fixtures/evidence-redaction/report.md
@@ -1,6 +1,7 @@
 # Evidence Redaction Fixture Pack
 
 - Public fixture import path: `verify/fixtures/evidence-redaction/`.
+- Public PR: https://github.com/auscaster/frantic-board/pull/115.
 - Safe JSON fixtures: `safe-redacted-secret.json`, `safe-redacted-local-path.json`, and `safe-redacted-private-url.json`.
 - Unsafe synthetic fixtures: `unsafe-synthetic-secret.json`, `unsafe-local-path.json`, and `unsafe-private-url-email.md`.
 - Secret rule: raw `SYNTHETIC_SECRET_DO_NOT_USE_*` values must be replaced with `[REDACTED_SECRET]`.

--- a/verify/fixtures/evidence-redaction/report.md
+++ b/verify/fixtures/evidence-redaction/report.md
@@ -1,0 +1,12 @@
+# Evidence Redaction Fixture Pack
+
+- Public fixture import path: `verify/fixtures/evidence-redaction/`.
+- Safe JSON fixtures: `safe-redacted-secret.json`, `safe-redacted-local-path.json`, and `safe-redacted-private-url.json`.
+- Unsafe synthetic fixtures: `unsafe-synthetic-secret.json`, `unsafe-local-path.json`, and `unsafe-private-url-email.md`.
+- Secret rule: raw `SYNTHETIC_SECRET_DO_NOT_USE_*` values must be replaced with `[REDACTED_SECRET]`.
+- Local path rule: user and machine-specific path roots must be replaced with `[LOCAL_PATH]`.
+- Private URL rule: non-public dashboards and tokenized internal links must be replaced with `[PRIVATE_URL]`.
+- Private email rule: personal or private inboxes must be replaced with `[PRIVATE_EMAIL]`.
+- Reviewer action: accept safe fixtures that preserve evidence shape and reject unsafe fixtures until the raw private values are removed.
+- Validation command: `node verify/09-check-evidence-redaction-fixtures.mjs`.
+- runx evidence command: `runx --version` returned `runx-cli 0.6.8`.

--- a/verify/fixtures/evidence-redaction/safe-redacted-local-path.json
+++ b/verify/fixtures/evidence-redaction/safe-redacted-local-path.json
@@ -1,0 +1,17 @@
+{
+  "summary": "Safe evidence example where a local filesystem path was generalized so the public artifact keeps context without exposing the operator machine.",
+  "observations": [
+    {
+      "fixture": "safe-redacted-local-path.json",
+      "category": "local_path",
+      "input_pattern": "C:\\Users\\agent\\Documents\\private-run\\receipt.json",
+      "public_value": "[LOCAL_PATH]/receipt.json",
+      "reviewer_action": "accept when the path root and username are removed"
+    },
+    {
+      "fixture": "safe-redacted-local-path.json",
+      "category": "evidence_shape",
+      "result": "valid_json_with_summary_and_observations"
+    }
+  ]
+}

--- a/verify/fixtures/evidence-redaction/safe-redacted-private-url.json
+++ b/verify/fixtures/evidence-redaction/safe-redacted-private-url.json
@@ -1,0 +1,19 @@
+{
+  "summary": "Safe evidence example where a private dashboard URL and operator email were replaced with neutral public-safe markers.",
+  "observations": [
+    {
+      "fixture": "safe-redacted-private-url.json",
+      "category": "private_url",
+      "input_pattern": "https://internal.example.invalid/tickets/123",
+      "public_value": "[PRIVATE_URL]",
+      "reviewer_action": "accept only when the live private URL is absent"
+    },
+    {
+      "fixture": "safe-redacted-private-url.json",
+      "category": "private_email",
+      "input_pattern": "user@example.invalid",
+      "public_value": "[PRIVATE_EMAIL]",
+      "reviewer_action": "accept only when the address local-part is absent"
+    }
+  ]
+}

--- a/verify/fixtures/evidence-redaction/safe-redacted-secret.json
+++ b/verify/fixtures/evidence-redaction/safe-redacted-secret.json
@@ -1,0 +1,17 @@
+{
+  "summary": "Safe evidence example where a provider token was detected and replaced with a stable redaction marker before publication.",
+  "observations": [
+    {
+      "fixture": "safe-redacted-secret.json",
+      "category": "secret",
+      "input_pattern": "SYNTHETIC_SECRET_DO_NOT_USE_*",
+      "public_value": "[REDACTED_SECRET]",
+      "reviewer_action": "accept when the raw secret value is absent"
+    },
+    {
+      "fixture": "safe-redacted-secret.json",
+      "category": "evidence_shape",
+      "result": "valid_json_with_summary_and_observations"
+    }
+  ]
+}

--- a/verify/fixtures/evidence-redaction/unsafe-local-path.json
+++ b/verify/fixtures/evidence-redaction/unsafe-local-path.json
@@ -1,0 +1,17 @@
+{
+  "summary": "Unsafe fixture containing local path details that should be generalized before evidence is made public.",
+  "observations": [
+    {
+      "fixture": "unsafe-local-path.json",
+      "category": "local_path",
+      "leaked_value": "C:\\Users\\agent\\Documents\\private-run\\receipt.json",
+      "expected_reviewer_action": "reject and ask for [LOCAL_PATH]/receipt.json"
+    },
+    {
+      "fixture": "unsafe-local-path.json",
+      "category": "local_path",
+      "leaked_value": "/home/agent/private-run/debug.log",
+      "expected_reviewer_action": "reject and ask for [LOCAL_PATH]/debug.log"
+    }
+  ]
+}

--- a/verify/fixtures/evidence-redaction/unsafe-private-url-email.md
+++ b/verify/fixtures/evidence-redaction/unsafe-private-url-email.md
@@ -1,0 +1,9 @@
+# Unsafe Private URL And Email
+
+This synthetic fixture should fail redaction review.
+
+- Private URL: `https://internal.example.invalid/tickets/123?token=SYNTHETIC_SECRET_DO_NOT_USE_url_token`
+- Private email: `user@example.invalid`
+- Expected reviewer action: reject and require `[PRIVATE_URL]` plus `[PRIVATE_EMAIL]`.
+
+No real credential, real customer data, or routable private service appears here.

--- a/verify/fixtures/evidence-redaction/unsafe-synthetic-secret.json
+++ b/verify/fixtures/evidence-redaction/unsafe-synthetic-secret.json
@@ -1,0 +1,11 @@
+{
+  "summary": "Unsafe fixture containing a synthetic secret sentinel that a verifier should block before public delivery.",
+  "observations": [
+    {
+      "fixture": "unsafe-synthetic-secret.json",
+      "category": "secret",
+      "leaked_value": "SYNTHETIC_SECRET_DO_NOT_USE_1234567890abcdef",
+      "expected_reviewer_action": "reject and ask for [REDACTED_SECRET]"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add reusable evidence redaction fixtures under `verify/fixtures/evidence-redaction/`.
- Include three safe JSON examples with `summary` and `observations`.
- Include three unsafe synthetic examples covering secrets, local paths, private URLs, and private emails.
- Add `verify/09-check-evidence-redaction-fixtures.mjs` to validate the fixture pack.

## Why
Frantic evidence needs to be public and useful without leaking secrets, local machine paths, private URLs, or private inboxes. This fixture pack gives reviewers and future verifier tests a shared positive/negative corpus.

## Validation
- `node verify/09-check-evidence-redaction-fixtures.mjs`
- Safe fixture JSON parse check for all `safe-*.json`
- `runx --version` -> `runx-cli 0.6.8`