### PR TITLE
Fix #247 – verify SKILL posting copy

### DIFF
--- a/fixtures/skill-posting/fail/SKILL.md
+++ b/fixtures/skill-posting/fail/SKILL.md
@@ -1,0 +1,14 @@
+# Vendor door — incomplete fixture
+
+## Procedure
+
+1. Call `fund_bounty` immediately to fund the posting.
+2. Use `post_bounty` after payment.
+
+## Tools
+
+- `get_posting` — read posting state.
+
+## Edge cases
+
+- Retry on timeout.

--- a/fixtures/skill-posting/pass/SKILL.md
+++ b/fixtures/skill-posting/pass/SKILL.md
@@ -1,0 +1,27 @@
+# Vendor door — Frantic posting operator copy (fixture)
+
+Operator instructions for vendors posting funded bounties at gofrantic.com.
+
+## Procedure
+
+1. **House screening** — every posting enters screening before it is visible or
+   fundable. Do not skip moderation; the house reviews scope, safety, and
+   acceptance criteria first.
+2. Draft the posting with `post_bounty` (title, deliverable, worker price).
+3. Inspect the draft with `get_posting` to confirm acceptance bullets and
+   verifier commands match intent.
+4. After screening approval, settle funds with `fund_bounty` so the FUNDED
+   badge appears before workers claim.
+
+## Tools
+
+- `post_bounty` — create a screened posting draft at the venue.
+- `get_posting` — read back the posting packet and acceptance criteria.
+- `fund_bounty` — attach funding after house screening clears the posting.
+
+## Edge cases
+
+- If screening is pending, `fund_bounty` must refuse: funding before approval
+  is blocked.
+- On `needs_agent`, stop and collect missing scope or policy context.
+- Receipt every transition; bind `receipt_ref` on funding and posting ids.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "frantic-board",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/*.mjs"
+  }
+}

--- a/scripts/ci-verify.sh
+++ b/scripts/ci-verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Local CI mirror for bounty #93 — run before opening PR when workflow scope is unavailable.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+npm test
+bash ./verify/08-check-skill-posting-copy.sh ./fixtures/skill-posting/pass/SKILL.md
+if bash ./verify/08-check-skill-posting-copy.sh ./fixtures/skill-posting/fail/SKILL.md; then
+  echo "expected fail fixture to be rejected" >&2
+  exit 1
+fi
+echo "PASS: all local CI checks"

--- a/src/skill.js
+++ b/src/skill.js
@@ -1,0 +1,91 @@
+/**
+ * Verify vendor-door SKILL.md operator copy for Frantic bounty postings.
+ * Checks required tool names and that house screening precedes funding.
+ */
+
+const REQUIRED_TOOLS = ["post_bounty", "get_posting", "fund_bounty"];
+
+const SCREENING_RE = /house\s+screening|screening/i;
+const FUNDING_RE = /\bfund(?:_bounty|ing)\b/i;
+
+/**
+ * @param {string} markdown - SKILL.md body
+ * @param {string} [checkedUrl] - URL where the SKILL.md was fetched
+ */
+export function verifySkillPostingCopy(markdown, checkedUrl = "") {
+  const lines = markdown.split(/\r?\n/);
+  const findings = {
+    checked_url: checkedUrl,
+    required_tools: {},
+    screening_before_funding: false,
+    checked_headings: [],
+    checked_lines: [],
+  };
+
+  for (const tool of REQUIRED_TOOLS) {
+    const idx = lines.findIndex((line) => line.includes(tool));
+    findings.required_tools[tool] = idx >= 0;
+    if (idx >= 0) {
+      findings.checked_lines.push({ line: idx + 1, text: lines[idx].trim() });
+    }
+  }
+
+  const screeningIdx = lines.findIndex((line) => SCREENING_RE.test(line));
+  const fundingIdx = lines.findIndex((line) => FUNDING_RE.test(line));
+  findings.screening_before_funding =
+    screeningIdx >= 0 && fundingIdx >= 0 && screeningIdx < fundingIdx;
+
+  if (screeningIdx >= 0) {
+    findings.checked_headings.push({
+      line: screeningIdx + 1,
+      heading: lines[screeningIdx].trim(),
+    });
+  }
+  if (fundingIdx >= 0) {
+    findings.checked_headings.push({
+      line: fundingIdx + 1,
+      heading: lines[fundingIdx].trim(),
+    });
+  }
+
+  const missing = REQUIRED_TOOLS.filter((t) => !findings.required_tools[t]);
+  const ok =
+    missing.length === 0 &&
+    findings.screening_before_funding &&
+    Boolean(checkedUrl);
+
+  return {
+    ok,
+    report: formatReport(findings, missing),
+    findings,
+  };
+}
+
+function formatReport(findings, missing) {
+  const parts = [
+    "# SKILL posting copy verification",
+    "",
+    `Checked URL: ${findings.checked_url || "(missing)"}`,
+    "",
+    "## Required tools",
+    ...REQUIRED_TOOLS.map(
+      (t) =>
+        `- ${t}: ${findings.required_tools[t] ? "present" : "MISSING"}`,
+    ),
+    "",
+    "## House screening before funding",
+    `- screening precedes funding: ${findings.screening_before_funding ? "yes" : "no"}`,
+    "",
+    "## Checked headings / lines",
+    ...findings.checked_headings.map(
+      (h) => `- line ${h.line}: ${h.heading}`,
+    ),
+    ...findings.checked_lines.map((l) => `- line ${l.line}: ${l.text}`),
+  ];
+
+  if (missing.length) {
+    parts.push("", `Missing tools: ${missing.join(", ")}`);
+  }
+
+  return parts.join("\n");
+}

--- a/test/skill.test.mjs
+++ b/test/skill.test.mjs
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { verifySkillPostingCopy } from "../src/skill.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, "..");
+const passMd = readFileSync(
+  join(root, "fixtures/skill-posting/pass/SKILL.md"),
+  "utf8",
+);
+const failMd = readFileSync(
+  join(root, "fixtures/skill-posting/fail/SKILL.md"),
+  "utf8",
+);
+const checkedUrl =
+  "https://raw.githubusercontent.com/auscaster/frantic-board/main/fixtures/skill-posting/pass/SKILL.md";
+
+test("pass fixture names post_bounty, get_posting, fund_bounty", () => {
+  const { ok, findings } = verifySkillPostingCopy(passMd, checkedUrl);
+  assert.equal(ok, true);
+  assert.equal(findings.required_tools.post_bounty, true);
+  assert.equal(findings.required_tools.get_posting, true);
+  assert.equal(findings.required_tools.fund_bounty, true);
+});
+
+test("pass fixture confirms house screening before funding", () => {
+  const { findings } = verifySkillPostingCopy(passMd, checkedUrl);
+  assert.equal(findings.screening_before_funding, true);
+});
+
+test("report includes checked URL and line references", () => {
+  const { report, findings } = verifySkillPostingCopy(passMd, checkedUrl);
+  assert.match(report, /Checked URL: https:\/\//);
+  assert.ok(findings.checked_lines.length >= 3);
+  assert.ok(findings.checked_headings.some((h) => /screening/i.test(h.heading)));
+});
+
+test("fail fixture is rejected", () => {
+  const { ok, findings } = verifySkillPostingCopy(failMd, checkedUrl);
+  assert.equal(ok, false);
+  assert.equal(findings.required_tools.post_bounty, true);
+  assert.equal(findings.screening_before_funding, false);
+});
+
+test("missing URL fails verification", () => {
+  const { ok } = verifySkillPostingCopy(passMd, "");
+  assert.equal(ok, false);
+});

--- a/verify/08-check-skill-posting-copy.sh
+++ b/verify/08-check-skill-posting-copy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Usage: ./verify/08-check-skill-posting-copy.sh <skill-md-path-or-url>
+# Verifies bounty 93 / issue 247: vendor-door SKILL posting copy.
+set -euo pipefail
+
+TARGET="${1:?usage: $0 <skill-md-path-or-url>}"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=""
+SKILL_PATH="$TARGET"
+CHECKED_URL="$TARGET"
+
+cleanup() { [ -n "$TMP" ] && rm -f "$TMP"; }
+trap cleanup EXIT
+
+if printf '%s' "$TARGET" | grep -Eq '^https?://'; then
+  TMP=$(mktemp)
+  code=$(curl -s -o "$TMP" -w '%{http_code}' -L --proto '=http,https' --max-time 20 "$TARGET" || echo 000)
+  [ "$code" = "200" ] || fail "SKILL.md not reachable (HTTP $code): $TARGET"
+  SKILL_PATH="$TMP"
+  CHECKED_URL="$TARGET"
+elif [ ! -f "$SKILL_PATH" ]; then
+  fail "SKILL.md not found: $TARGET"
+fi
+
+cd "$ROOT"
+node --input-type=module - "$SKILL_PATH" "$CHECKED_URL" <<'NODE'
+import { readFileSync } from "node:fs";
+import { verifySkillPostingCopy } from "./src/skill.js";
+
+const skillPath = process.argv[2];
+const checkedUrl = process.argv[3];
+const markdown = readFileSync(skillPath, "utf8");
+const { ok, report } = verifySkillPostingCopy(markdown, checkedUrl);
+
+console.log(report);
+if (!ok) {
+  process.exit(1);
+}
+NODE
+
+echo "PASS: SKILL posting copy names post_bounty, get_posting, fund_bounty; screening precedes funding"


### PR DESCRIPTION
## Summary

Implements bounty #93 / issue #247: machine verification that vendor-door SKILL.md operator copy names \post_bounty\, \get_posting\, and \und_bounty\, and documents house screening before funding.

- \src/skill.js\ — core verifier + markdown report with checked URL and line refs
- \erify/08-check-skill-posting-copy.sh\ — shell verifier for delivery packets
- \ixtures/skill-posting/\ — pass/fail SKILL.md fixtures
- \	est/skill.test.mjs\ — unit tests (node:test)
- \scripts/ci-verify.sh\ — local CI mirror

## Verification

\\\sh
npm test
bash ./verify/08-check-skill-posting-copy.sh ./fixtures/skill-posting/pass/SKILL.md
bash scripts/ci-verify.sh
\\\

Closes #247
/claim #93


Made with [Cursor](https://cursor.com)