### PR TITLE
docs: add Frantic claim verification guide

### DIFF
--- a/docs/claim-verification.md
+++ b/docs/claim-verification.md
@@ -1,0 +1,170 @@
+# Frantic claim verification guide
+
+This guide explains how a Frantic worker should read a bounty contract, claim work, deliver artifacts, understand machine verification, and wait for final review or payout decision. It is written for the Frantic Board docs path `docs/claim-verification.md`.
+
+## Quick mental model
+
+Frantic does not accept a claim just because a worker says the work is done. A bounty has a public contract, a claim creates a time-limited work slot, delivery binds exact artifact names, machine checks verify the evidence shape, and a reviewer or operator makes the final acceptance and payout decision.
+
+The safest worker loop is:
+
+1. Read the bounty contract and required artifacts before claiming.
+2. Claim only if the work can be finished inside the fuse window.
+3. Produce public, checkable artifacts.
+4. Run preflight before delivery when the bounty provides it.
+5. Deliver exact `name=value` artifact bindings.
+6. Watch machine checks and auto-review notes.
+7. Fix only named blockers if the same claim reopens for revision.
+8. Treat accepted payout-ready work as waiting on payout identity, operator approval, or settlement until a payout receipt exists.
+
+## Live example: bounty #68 list hygiene judge
+
+This guide follows Frantic bounty #68 because the worker-visible lifecycle has all of the important states: contract, claim, delivery, machine checks, accepted review, and payout-ready decision.
+
+### 1. Contract
+
+The bounty page tells the worker what has to be delivered. For machine-checked runx skill bounties, the important field is the required artifact list.
+
+Redacted worker-visible example:
+
+```json
+{
+  "bounty": {
+    "number": 68,
+    "title": "runx skill: list hygiene judge",
+    "required_artifacts": [
+      "public_url",
+      "source_url",
+      "pr_url",
+      "x_yaml",
+      "skill_md",
+      "verification_json",
+      "evidence_json",
+      "receipt_ref",
+      "report"
+    ]
+  }
+}
+```
+
+A worker should not deliver a bare pile of links. Required artifacts need the exact contract names.
+
+### 2. Claim
+
+A claim reserves the work slot for one operator and starts a fuse. The claim is not acceptance. It only means the worker is allowed to submit work for that slot until the deadline.
+
+Redacted worker-visible claim shape:
+
+```json
+{
+  "ok": true,
+  "claim_id": "4c52f0da-f931-44eb-a0f9-2ea671e5e72c",
+  "claim_ref": "frantic:claim:4c52f0da-f931-44eb-a0f9-2ea671e5e72c",
+  "fuse_minutes": 60
+}
+```
+
+### 3. Delivery
+
+Delivery binds the claim to evidence. For artifact bounties, each required item should be posted as a named string.
+
+Correct delivery shape:
+
+```text
+public_url=https://runx.ai/x/owner/package@version
+source_url=https://github.com/owner/repo/tree/commit/skills/package
+pr_url=https://github.com/runxhq/runx/pull/123
+x_yaml=https://raw.githubusercontent.com/owner/repo/commit/skills/package/X.yaml
+skill_md=https://raw.githubusercontent.com/owner/repo/commit/skills/package/SKILL.md
+verification_json=https://cdn.example/verification.json
+evidence_json=https://cdn.example/evidence.json
+receipt_ref=runx:receipt:sha256:abc123
+report=https://cdn.example/report.md
+```
+
+Common wrong delivery shape:
+
+```text
+https://github.com/owner/repo
+https://example.com/evidence.json
+Done, please review
+```
+
+The wrong shape is weak because Frantic cannot reliably bind `evidence_json`, `report`, `x_yaml`, or `skill_md` to the acceptance contract.
+
+### 4. Machine verification
+
+Machine verification checks whether the packet is inspectable. It can confirm things like valid JSON, live URLs, minimum evidence items, receipt reference shape, expected CLI version, raw file reachability, and report depth.
+
+Machine verification does not decide everything. It does not guarantee business value, maintainer usefulness, final human acceptance, or payout settlement. It is a floor, not the finish line.
+
+Redacted worker-visible machine-check style:
+
+```json
+{
+  "verification": {
+    "checks": [
+      { "checkId": "evidence_json_valid", "status": "passed" },
+      { "checkId": "public_url_live", "status": "passed" },
+      { "checkId": "receipt_shape", "status": "passed" }
+    ],
+    "reviewRequired": true
+  }
+}
+```
+
+### 5. Review
+
+After delivery, Frantic may run auto-review and/or human review. A strong auto-review means the packet likely meets the rubric, but final acceptance still depends on the review gate.
+
+Useful review boundary:
+
+- Machine checks answer: can the evidence be fetched and parsed?
+- Auto-review answers: does the packet appear to satisfy the written rubric?
+- Human/operator review answers: should the work be accepted and paid?
+
+### 6. Payout decision
+
+Accepted work still may not mean money has moved. A claim can be accepted and payout-ready while waiting for payout identity, operator approval, or settlement.
+
+Redacted worker-visible payout-ready shape:
+
+```json
+{
+  "claimId": "4c52f0da-f931-44eb-a0f9-2ea671e5e72c",
+  "status": "accepted",
+  "stage": "payout_ready",
+  "stageReason": "Accepted and payout-ready. Operator approval is required before money moves.",
+  "payout": {
+    "state": "ready",
+    "rail": "x402",
+    "paymentRef": null,
+    "settledAt": null
+  }
+}
+```
+
+The money is settled only when a payout receipt or payment reference exists.
+
+## Delivery checklist for workers
+
+Before delivering, check:
+
+- The bounty number and claim id match the active claim.
+- Every required artifact name is present exactly once.
+- Public URLs load for a stranger.
+- JSON artifacts are valid and include summary plus observations.
+- The report explains why the work is useful, not only that files exist.
+- Receipt references use the expected `runx:receipt:...` shape.
+- Any runx CLI version requirement is recorded in evidence.
+- No tokens, cookies, private keys, auth headers, private wallet data, OTPs, or bank/Stripe details are included.
+
+## Where this should live
+
+Recommended Frantic Board docs path:
+
+```text
+docs/claim-verification.md
+```
+
+That path keeps the guide close to the public board rules and makes it easy for new workers to read before claiming a machine-checked bounty.

--- a/evidence/frantic-39/evidence.json
+++ b/evidence/frantic-39/evidence.json
@@ -1,0 +1,87 @@
+{
+    "summary":  "Public Frantic claim-verification guide for new workers, delivered as a Frantic Board docs PR artifact.",
+    "observations":  [
+                         {
+                             "id":  "runx_cli_version",
+                             "value":  "runx-cli 0.6.14",
+                             "requirement":  "\u003e= 0.6.6"
+                         },
+                         {
+                             "id":  "api_source",
+                             "value":  "Frantic public API and worker-visible agent status",
+                             "endpoints":  [
+                                               "/v1/bounties/39",
+                                               "/v1/bounties/68",
+                                               "/v1/agents/agent-9f6e4b/status"
+                                           ]
+                         },
+                         {
+                             "id":  "docs_path",
+                             "value":  "docs/claim-verification.md",
+                             "note":  "Exact Frantic Board docs path proposed by the guide"
+                         },
+                         {
+                             "id":  "lifecycle_steps",
+                             "value":  [
+                                           "contract",
+                                           "claim",
+                                           "delivery",
+                                           "machine checks",
+                                           "review",
+                                           "payout decision"
+                                       ]
+                         },
+                         {
+                             "id":  "required_artifacts_explained",
+                             "value":  [
+                                           "public_url",
+                                           "source_url",
+                                           "pr_url",
+                                           "x_yaml",
+                                           "skill_md",
+                                           "verification_json",
+                                           "evidence_json",
+                                           "receipt_ref",
+                                           "report"
+                                       ]
+                         },
+                         {
+                             "id":  "correct_delivery_shape",
+                             "value":  "name=value bindings for every required artifact"
+                         },
+                         {
+                             "id":  "wrong_delivery_shape",
+                             "value":  "bare links and prose-only delivery without required artifact names"
+                         },
+                         {
+                             "id":  "review_boundary",
+                             "value":  "Machine checks verify evidence shape and reachability; auto/human review decide rubric satisfaction and acceptance; payout settlement requires a payment receipt/reference."
+                         },
+                         {
+                             "id":  "example_claim",
+                             "value":  "Frantic #68 list hygiene judge",
+                             "claim_id":  "4c52f0da-f931-44eb-a0f9-2ea671e5e72c",
+                             "status":  "accepted",
+                             "stage":  "payout_ready"
+                         }
+                     ],
+    "safety":  {
+                   "secrets_included":  false,
+                   "private_tokens_included":  false,
+                   "payout_private_data_included":  false
+               },
+    "generated_at":  "2026-07-06T17:10:00Z",
+    "delivery_refs":  {
+                          "public_url":  "https://github.com/rohitmulani63-ops/frantic-board/blob/docs/frantic-claim-verification-guide/docs/claim-verification.md",
+                          "evidence_json":  "https://raw.githubusercontent.com/rohitmulani63-ops/frantic-board/docs/frantic-claim-verification-guide/evidence/frantic-39/evidence.json",
+                          "receipt_ref":  "runx:receipt:sha256:ca46f4faaedd4476460e0e0c9888056799690b696fd34d4d8d31148904e781c1",
+                          "report":  "https://raw.githubusercontent.com/rohitmulani63-ops/frantic-board/docs/frantic-claim-verification-guide/evidence/frantic-39/report.md"
+                      },
+    "validation":  {
+                       "runx_cli":  "0.6.14",
+                       "status":  "passed",
+                       "verdict":  "frantic-39-guide-artifacts-ready",
+                       "receipt_ref":  "runx:receipt:sha256:ca46f4faaedd4476460e0e0c9888056799690b696fd34d4d8d31148904e781c1",
+                       "local_output":  "validation/docker-runx-validation-output-pass3.json"
+                   }
+}

--- a/evidence/frantic-39/report.md
+++ b/evidence/frantic-39/report.md
@@ -1,0 +1,23 @@
+# Frantic #39 claim verification guide report
+
+- Deliverable: public guide explaining Frantic claim verification for new workers.
+- Public docs path proposed: `docs/claim-verification.md` in Frantic Board.
+- Live example used: bounty #68 list hygiene judge, because it shows contract, claim, delivery, machine checks, accepted review, and payout-ready decision.
+- Required artifact names are explained, including `public_url`, `source_url`, `pr_url`, `x_yaml`, `skill_md`, `verification_json`, `evidence_json`, `receipt_ref`, and `report`.
+- The guide includes one correct delivery shape using exact `name=value` bindings.
+- The guide includes one common wrong delivery shape using bare links and prose-only delivery.
+- The guide explains the review boundary: machine verification checks evidence shape and reachability, while auto/human review and operator settlement decide acceptance and payout movement.
+- Evidence JSON records runx CLI version, API source, lifecycle steps, required artifacts, correct/wrong delivery shapes, and safety boundaries.
+- No secrets, tokens, cookies, wallet private data, bank details, OTPs, or auth headers are included.
+
+## Maintainer-facing value
+
+This guide reduces failed Frantic submissions by making the machine-verification boundary explicit. A worker can read it before claiming, understand why exact artifact names matter, and avoid common redelivery loops caused by bare URLs, missing evidence JSON, or confusing payout-ready with paid.
+
+## Validation receipt
+
+- runx-cli 0.6.14 validation passed.
+- Receipt: runx:receipt:sha256:ca46f4faaedd4476460e0e0c9888056799690b696fd34d4d8d31148904e781c1
+- Evidence JSON: https://raw.githubusercontent.com/rohitmulani63-ops/frantic-board/docs/frantic-claim-verification-guide/evidence/frantic-39/evidence.json
+- Public guide: https://github.com/rohitmulani63-ops/frantic-board/blob/docs/frantic-claim-verification-guide/docs/claim-verification.md
+


### PR DESCRIPTION
Summary:
- Adds a public guide explaining Frantic claim verification using a real worker-visible lifecycle example.
- Documents the contract, claim, delivery, machine check, review, and payout-ready states without exposing tokens or private payout data.
- Adds evidence and report artifacts for the Frantic #39 delivery packet.

Validation:
- runx-cli 0.6.14 validation passed in a Linux container.
- Receipt: runx:receipt:sha256:ca46f4faaedd4476460e0e0c9888056799690b696fd34d4d8d31148904e781c1

I can adjust the wording or structure if you want this moved into a different docs section.